### PR TITLE
Switch prefix to use App id vs Installation id

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ const regex = /\n\n<!-- probot = (.*) -->/
 
 module.exports = (context, issue = null) => {
   const github = context.github
-  const prefix = context.payload.installation.id
+  let prefix = process.env.APP_ID
+  const oldPrefix = context.payload.installation.id
 
   if (!issue) issue = context.issue()
 
@@ -17,7 +18,8 @@ module.exports = (context, issue = null) => {
       const match = body.match(regex)
 
       if (match) {
-        const data = JSON.parse(match[1])[prefix]
+        const json = JSON.parse(match[1])
+        const data = json[prefix] || json[oldPrefix]
         return key ? data && data[key] : data
       }
     },
@@ -33,6 +35,9 @@ module.exports = (context, issue = null) => {
         return ''
       })
 
+      if (!prefix) {
+        prefix = oldPrefix
+      }
       if (!data[prefix]) data[prefix] = {}
 
       if (typeof key === 'object') {


### PR DESCRIPTION
Based on conversation [here](https://probot-talk.slack.com/archives/C6S4FC8AF/p1530118468000322), this PR updates proposes a change to metadata to use the App id instead of Installation id while maintaining backward compatibility.
