### PR TITLE
Update Jest to v23.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,14 @@
   },
   "homepage": "https://github.com/probot/metadata#readme",
   "devDependencies": {
-    "jest": "^22.1.4",
+    "jest": "^23.6.0",
     "probot": "^0.11.0",
     "standard": "^10.0.3"
   },
   "standard": {
     "env": "jest"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
This PR updates Jest v23.6.0. It also tells Jest to run tests in the node environment instead of the [default jsdom environment](https://jestjs.io/docs/en/configuration.html#testenvironment-string).