### PR TITLE
fix: Protect against PRs with null bodies

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = (context, issue = null) => {
       let body = issue.body
 
       if (!body) {
-        body = (await github.issues.get(issue)).data.body
+        body = (await github.issues.get(issue)).data.body || ''
       }
 
       const match = body.match(regex)

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = (context, issue = null) => {
       let body = issue.body
       let data = {}
 
-      if (!body) body = (await github.issues.get(issue)).data.body
+      if (!body) body = (await github.issues.get(issue)).data.body || ''
 
       body = body.replace(regex, (_, json) => {
         data = JSON.parse(json)

--- a/test/metadata.test.js
+++ b/test/metadata.test.js
@@ -165,6 +165,48 @@ describe('metadata', () => {
     })
   })
 
+  describe('on an issue with no content in the body', () => {
+    beforeEach(() => {
+      github.issues.get.mockImplementation(() => Promise.resolve({
+        data: {body: null}
+      }))
+    })
+
+    describe('set', () => {
+      test('sets new metadata', async () => {
+        await metadata(context).set('hello', 'world')
+
+        expect(github.issues.update).toHaveBeenCalledWith({
+          owner: 'foo',
+          repo: 'bar',
+          number: 42,
+          body: '\n\n<!-- probot = {"1":{"hello":"world"}} -->'
+        })
+      })
+
+      test('sets an object', async () => {
+        await metadata(context).set({hello: 'world'})
+
+        expect(github.issues.update).toHaveBeenCalledWith({
+          owner: 'foo',
+          repo: 'bar',
+          number: 42,
+          body: '\n\n<!-- probot = {"1":{"hello":"world"}} -->'
+        })
+      })
+    })
+
+    describe('get', () => {
+      test('returns undefined for unknown key', async () => {
+        expect(await metadata(context).get('unknown')).toEqual(undefined)
+      })
+
+      test('returns undefined without a key', async() => {
+        expect(await metadata(context).get()).toEqual(undefined)
+      })
+    })
+  })
+
   describe('when given body in issue params', () => {
     const issue = {
       owner: 'foo',


### PR DESCRIPTION
If a pull request does not have any body text, the GitHub API will return `null` instead of an empty string, causing an exception to be thrown when `probot-metadata` attempts to call `match` on that value. This PR adds a default value of empty string for the PR body.