### PR TITLE
d.ts: Add declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+import { Context } from "probot";
+
+type StringOrNumber = number | string;
+type Key =
+  | { [key: string]: StringOrNumber }
+  | StringOrNumber[]
+  | StringOrNumber;
+type Value = Key;
+
+declare function metadata(
+  context: Context,
+  issue?: { body: string; [key: string]: any }
+): {
+  get(key?: Key): Promise<any>;
+  set(key: Key, value: Value): Promise<any>;
+};
+
+export = metadata;


### PR DESCRIPTION
Adding typescript declaration file would simplify usage of package ``probot-metadata`` in typescripts projects. 